### PR TITLE
Add dark mode and usability improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import Footer from './components/Footer';
-import HomePage from './pages/HomePage';
-import FormulasPage from './pages/FormulasPage';
-import FormulaDetailPage from './pages/FormulaDetailPage';
-import QuotePage from './pages/QuotePage';
-import GalleryPage from './pages/GalleryPage';
-import AboutPage from './pages/AboutPage';
-import ContactPage from './pages/ContactPage';
+import BackToTopButton from './components/BackToTopButton';
 import ScrollToTop from './components/ScrollToTop';
+import { Suspense, lazy } from 'react';
+
+const HomePage = lazy(() => import('./pages/HomePage'));
+const FormulasPage = lazy(() => import('./pages/FormulasPage'));
+const FormulaDetailPage = lazy(() => import('./pages/FormulaDetailPage'));
+const QuotePage = lazy(() => import('./pages/QuotePage'));
+const GalleryPage = lazy(() => import('./pages/GalleryPage'));
+const AboutPage = lazy(() => import('./pages/AboutPage'));
+const ContactPage = lazy(() => import('./pages/ContactPage'));
 
 function App() {
   return (
@@ -18,17 +21,20 @@ function App() {
       <div className="flex flex-col min-h-screen">
         <Header />
         <main className="flex-grow">
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/formules" element={<FormulasPage />} />
-            <Route path="/formules/:id" element={<FormulaDetailPage />} />
-            <Route path="/devis" element={<QuotePage />} />
-            <Route path="/galerie" element={<GalleryPage />} />
-            <Route path="/a-propos" element={<AboutPage />} />
-            <Route path="/contact" element={<ContactPage />} />
-          </Routes>
+          <Suspense fallback={<div className="p-8 text-center">Chargement...</div>}>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/formules" element={<FormulasPage />} />
+              <Route path="/formules/:id" element={<FormulaDetailPage />} />
+              <Route path="/devis" element={<QuotePage />} />
+              <Route path="/galerie" element={<GalleryPage />} />
+              <Route path="/a-propos" element={<AboutPage />} />
+              <Route path="/contact" element={<ContactPage />} />
+            </Routes>
+          </Suspense>
         </main>
         <Footer />
+        <BackToTopButton />
       </div>
     </BrowserRouter>
   );

--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react';
+import { ArrowUp } from 'lucide-react';
+
+const BackToTopButton = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.scrollY > 300) {
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-6 right-6 p-3 rounded-full bg-accent text-white shadow-lg hover:bg-accent-dark transition-colors z-50"
+      aria-label="Revenir en haut"
+    >
+      <ArrowUp size={20} />
+    </button>
+  );
+};
+
+export default BackToTopButton;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { NavLink, Link } from 'react-router-dom';
-import { Menu, X, ChefHat } from 'lucide-react';
+import { Menu, X, ChefHat, Moon, Sun } from 'lucide-react';
 
 const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+  );
 
   useEffect(() => {
     const handleScroll = () => {
@@ -19,6 +22,15 @@ const Header = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
   const toggleMenu = () => {
     setIsOpen(!isOpen);
   };
@@ -27,17 +39,21 @@ const Header = () => {
     setIsOpen(false);
   };
 
+  const toggleTheme = () => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  };
+
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `relative px-3 py-2 font-medium transition-colors duration-300 hover:text-accent ${
-      isActive ? 'text-accent' : 'text-gray-800'
+      isActive ? 'text-accent' : 'text-gray-800 dark:text-gray-100'
     } ${
       isActive ? 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-accent' : ''
     }`;
 
   return (
-    <header 
+    <header
       className={`fixed w-full z-50 transition-all duration-300 ${
-        isScrolled ? 'bg-white shadow-md py-2' : 'bg-transparent py-4'
+        isScrolled ? 'bg-white dark:bg-gray-800 shadow-md py-2' : 'bg-transparent py-4'
       }`}
     >
       <div className="container-custom px-4 mx-auto flex justify-between items-center">
@@ -64,12 +80,21 @@ const Header = () => {
           </NavLink>
         </nav>
 
-        <Link to="/devis" className="hidden md:block btn btn-primary">
-          Demander un devis
-        </Link>
+        <div className="flex items-center space-x-4">
+          <button
+            onClick={toggleTheme}
+            className="hidden md:flex text-gray-800 dark:text-gray-100 focus:outline-none"
+            aria-label="Basculer le thème"
+          >
+            {theme === 'dark' ? <Sun size={24} /> : <Moon size={24} />}
+          </button>
+          <Link to="/devis" className="hidden md:block btn btn-primary">
+            Demander un devis
+          </Link>
+        </div>
 
         <button
-          className="md:hidden text-gray-800 focus:outline-none"
+          className="md:hidden text-gray-800 dark:text-gray-100 focus:outline-none"
           onClick={toggleMenu}
           aria-label="Menu"
         >
@@ -79,7 +104,7 @@ const Header = () => {
 
       {/* Mobile menu */}
       <div
-        className={`fixed inset-0 bg-white z-40 transform transition-transform duration-300 ease-in-out ${
+        className={`fixed inset-0 bg-white dark:bg-gray-800 z-40 transform transition-transform duration-300 ease-in-out ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         } md:hidden`}
       >
@@ -90,7 +115,7 @@ const Header = () => {
               <span className="font-display text-2xl font-bold">Jouaux Traiteur</span>
             </Link>
             <button
-              className="text-gray-800 focus:outline-none"
+              className="text-gray-800 dark:text-gray-100 focus:outline-none"
               onClick={toggleMenu}
               aria-label="Close menu"
             >
@@ -102,7 +127,7 @@ const Header = () => {
             <NavLink
               to="/"
               className={({ isActive }) =>
-                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800'}`
+                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800 dark:text-gray-100'}`
               }
               onClick={closeMenu}
             >
@@ -111,7 +136,7 @@ const Header = () => {
             <NavLink
               to="/formules"
               className={({ isActive }) =>
-                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800'}`
+                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800 dark:text-gray-100'}`
               }
               onClick={closeMenu}
             >
@@ -120,7 +145,7 @@ const Header = () => {
             <NavLink
               to="/galerie"
               className={({ isActive }) =>
-                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800'}`
+                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800 dark:text-gray-100'}`
               }
               onClick={closeMenu}
             >
@@ -129,7 +154,7 @@ const Header = () => {
             <NavLink
               to="/a-propos"
               className={({ isActive }) =>
-                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800'}`
+                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800 dark:text-gray-100'}`
               }
               onClick={closeMenu}
             >
@@ -138,7 +163,7 @@ const Header = () => {
             <NavLink
               to="/contact"
               className={({ isActive }) =>
-                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800'}`
+                `py-2 ${isActive ? 'text-accent font-semibold' : 'text-gray-800 dark:text-gray-100'}`
               }
               onClick={closeMenu}
             >
@@ -146,7 +171,13 @@ const Header = () => {
             </NavLink>
           </nav>
 
-          <div className="mt-auto">
+          <div className="mt-auto space-y-4">
+            <button
+              onClick={toggleTheme}
+              className="w-full flex justify-center items-center py-2 rounded-full bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-100"
+            >
+              {theme === 'dark' ? <Sun size={24} /> : <Moon size={24} />}
+            </button>
             <Link
               to="/devis"
               className="block w-full btn btn-primary text-center"

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 
 @layer base {
   body {
-    @apply font-body text-gray-800;
+    @apply font-body text-gray-800 bg-white dark:bg-gray-900 dark:text-gray-100;
   }
   h1, h2, h3, h4, h5, h6 {
     @apply font-display;
@@ -47,7 +47,7 @@
   }
   
   .card {
-    @apply bg-white rounded-lg shadow-md overflow-hidden transition-all duration-300 hover:shadow-lg;
+    @apply bg-white rounded-lg shadow-md overflow-hidden transition-all duration-300 hover:shadow-lg dark:bg-gray-800;
   }
   
   .input {

--- a/src/pages/FormulasPage.tsx
+++ b/src/pages/FormulasPage.tsx
@@ -13,8 +13,7 @@ const categories = [
 
 const FormulasPage = () => {
   const [activeCategory, setActiveCategory] = useState('all');
-  const [filteredFormulas, setFilteredFormulas] = useState<Formula[]>(formulas);
-  const [visibleFormulas, setVisibleFormulas] = useState<Formula[]>([]);
+  const [visibleFormulas, setVisibleFormulas] = useState<Formula[]>(formulas);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -23,8 +22,6 @@ const FormulasPage = () => {
     const filtered = activeCategory === 'all' 
       ? formulas 
       : formulas.filter(formula => formula.category === activeCategory);
-    
-    setFilteredFormulas(filtered);
     
     // Simulate loading for smoother transitions
     setTimeout(() => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- support dark mode in Tailwind and global styles
- add dark mode toggle to header
- lazy load pages with React Suspense
- add floating back-to-top button
- fix lint issue in `FormulasPage`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68404531d6fc832b89a2fce461135406