### PR TITLE
Improve quote form date handling

### DIFF
--- a/src/pages/QuotePage.tsx
+++ b/src/pages/QuotePage.tsx
@@ -24,6 +24,7 @@ const initialFormData: FormData = {
 };
 
 const QuotePage = () => {
+  const today = new Date().toISOString().split('T')[0];
   const [formData, setFormData] = useState<FormData>(initialFormData);
   const [errors, setErrors] = useState<Partial<FormData>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -213,7 +214,7 @@ const QuotePage = () => {
                         value={formData.eventDate}
                         onChange={handleChange}
                         className={`input ${errors.eventDate ? 'border-red-500 focus:ring-red-500' : ''}`}
-                        min={new Date().toISOString().split('T')[0]}
+                        min={today}
                       />
                       {errors.eventDate && <p className="mt-1 text-sm text-red-500">{errors.eventDate}</p>}
                     </div>


### PR DESCRIPTION
## Summary
- add constant for today's date in quote form
- use that constant as `min` on the event date input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684054f54dfc832baf60fd1858e1a55c